### PR TITLE
Point server static dir to built frontend bundle

### DIFF
--- a/tender_portal/server.py
+++ b/tender_portal/server.py
@@ -17,7 +17,7 @@ from urllib.parse import parse_qs
 
 from . import auth, database, models
 
-STATIC_DIR = Path(__file__).resolve().parent.parent / "frontend"
+STATIC_DIR = Path(__file__).resolve().parent.parent / "frontend" / "dist"
 EXPORT_DIR = Path(__file__).resolve().parent / "exports"
 EXPORT_DIR.mkdir(parents=True, exist_ok=True)
 
@@ -122,8 +122,11 @@ class TenderPortalRequestHandler(BaseHTTPRequestHandler):
         safe_path = posixpath.normpath(path.lstrip("/"))
         file_path = STATIC_DIR / safe_path
         if not file_path.exists() or not file_path.is_file():
-            self.send_error(HTTPStatus.NOT_FOUND)
-            return
+            # Serve the SPA entry point for unknown routes.
+            file_path = STATIC_DIR / "index.html"
+            if not file_path.exists():
+                self.send_error(HTTPStatus.NOT_FOUND)
+                return
         content_type = "text/plain"
         if file_path.suffix == ".html":
             content_type = "text/html; charset=utf-8"


### PR DESCRIPTION
## Summary
- update the Python server so static assets are served from the compiled `frontend/dist` directory
- return `index.html` for unknown paths to preserve the SPA fallback

## Testing
- pytest
- npm install *(fails: 403 Forbidden fetching @radix-ui/react-dialog from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c56f70f48325ae469b5f81e89e40