### PR TITLE
Refactor tender creation modal into step-by-step flow

### DIFF
--- a/frontend/src/components/forms/modal-form.tsx
+++ b/frontend/src/components/forms/modal-form.tsx
@@ -22,19 +22,35 @@ export function ModalForm({
       <Dialog.Trigger asChild>{trigger}</Dialog.Trigger>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 z-40 bg-slate-900/40" />
-        <Dialog.Content className="fixed inset-0 z-50 mx-auto my-24 w-full max-w-xl rounded-3xl bg-white p-8 shadow-soft">
-          <Dialog.Title className="text-xl font-semibold text-slate-900">{title}</Dialog.Title>
-          {description ? (
-            <Dialog.Description className="mt-2 text-sm text-slate-500">
-              {description}
-            </Dialog.Description>
-          ) : null}
-          <div className="mt-6 space-y-4">{children}</div>
-          <div className="mt-8 flex justify-end gap-3">
-            <Dialog.Close asChild>
-              <Button variant="ghost">{t("cancel")}</Button>
-            </Dialog.Close>
-            <Button onClick={onSubmit}>{t("save")}</Button>
+        <Dialog.Content className="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-8">
+          <div className="flex h-[95vh] w-[95vw] max-h-[95vh] max-w-[95vw] flex-col overflow-hidden rounded-3xl bg-white shadow-soft">
+            <header className="sticky top-0 z-10 border-b border-border bg-white/95 px-6 py-4 backdrop-blur">
+              <div className="flex flex-wrap items-start justify-between gap-4">
+                <div className="space-y-1">
+                  <Dialog.Title className="text-xl font-semibold text-slate-900">{title}</Dialog.Title>
+                  {description ? (
+                    <Dialog.Description className="text-sm text-slate-500">
+                      {description}
+                    </Dialog.Description>
+                  ) : null}
+                </div>
+                <div className="flex items-center gap-3">
+                  <Dialog.Close asChild>
+                    <Button variant="ghost">{t("cancel")}</Button>
+                  </Dialog.Close>
+                  <Button onClick={onSubmit}>{t("save")}</Button>
+                </div>
+              </div>
+            </header>
+            <div className="flex-1 overflow-y-auto px-6 py-6">{children}</div>
+            <footer className="sticky bottom-0 z-10 border-t border-border bg-white/95 px-6 py-4 backdrop-blur">
+              <div className="flex items-center justify-end gap-3">
+                <Dialog.Close asChild>
+                  <Button variant="ghost">{t("cancel")}</Button>
+                </Dialog.Close>
+                <Button onClick={onSubmit}>{t("save")}</Button>
+              </div>
+            </footer>
           </div>
         </Dialog.Content>
       </Dialog.Portal>


### PR DESCRIPTION
## Summary
- restyle the shared modal wrapper to occupy 95% of the viewport with sticky save and cancel controls
- rework the tender creation experience into a tabbed stepper that captures basics, dates, site visit, attachments, specification books, and quote details while preserving entered values
- gate validation to the active step until submission and persist added attachments/specification books in the resulting payload

## Testing
- npm install *(fails: 403 Forbidden fetching @radix-ui/react-dialog)*

------
https://chatgpt.com/codex/tasks/task_e_68d69927a1488325af018d9e4841b2a8