### PR TITLE
Add site visit tracking with attachments

### DIFF
--- a/frontend/src/components/forms/file-uploader.tsx
+++ b/frontend/src/components/forms/file-uploader.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useId, useState } from "react";
 import { Button } from "@/components/ui/button";
 import type { Attachment } from "@/utils/types";
 import { Badge } from "@/components/ui/badge";
@@ -10,11 +10,12 @@ type FileUploaderProps = {
 
 export function FileUploader({ attachments, onFilesSelected }: FileUploaderProps) {
   const [isHovering, setHovering] = useState(false);
+  const inputId = useId();
 
   return (
     <div className="space-y-4">
       <label
-        htmlFor="attachment-upload"
+        htmlFor={inputId}
         onDragOver={(event) => {
           event.preventDefault();
           setHovering(true);
@@ -30,7 +31,7 @@ export function FileUploader({ attachments, onFilesSelected }: FileUploaderProps
         className="flex flex-col items-center justify-center gap-3 rounded-3xl border-2 border-dashed border-border bg-muted/60 p-8 text-center"
       >
         <input
-          id="attachment-upload"
+          id={inputId}
           type="file"
           multiple
           className="hidden"

--- a/frontend/src/data/seed.ts
+++ b/frontend/src/data/seed.ts
@@ -49,6 +49,36 @@ const attachments: Attachment[] = [
   }
 ];
 
+const siteVisitPhotos: Attachment[] = [
+  {
+    id: "att-photo-1",
+    fileName: "Clinic_Visit_01.jpg",
+    fileSize: 1843200,
+    uploadedAt: date(-9),
+    uploader: "Salem Haddad",
+    previewUrl: "https://dummyimage.com/600x400/15803d/ffffff&text=Visit+1"
+  },
+  {
+    id: "att-photo-2",
+    fileName: "Clinic_Visit_02.jpg",
+    fileSize: 1761280,
+    uploadedAt: date(-9),
+    uploader: "Salem Haddad",
+    previewUrl: "https://dummyimage.com/600x400/0369a1/ffffff&text=Visit+2"
+  }
+];
+
+const tripoliVisitPhotos: Attachment[] = [
+  {
+    id: "att-photo-3",
+    fileName: "Tripoli_Site_Visit.jpg",
+    fileSize: 2048000,
+    uploadedAt: date(-62),
+    uploader: "Layla Ben Ali",
+    previewUrl: "https://dummyimage.com/600x400/7c3aed/ffffff&text=Tripoli"
+  }
+];
+
 const specificationReceipts: SpecificationBook["attachment"][] = [
   {
     id: "att-spec-1",
@@ -111,10 +141,12 @@ export const tenders: Tender[] = [
     dueDate: date(7),
     createdAt: date(-30),
     siteVisit: {
+      required: true,
+      completed: true,
+      photos: siteVisitPhotos,
       date: date(-10),
       assignee: "Salem Haddad",
-      notes: "Site visit completed with municipality engineer. Photos archived.",
-      completed: true
+      notes: "Site visit completed with municipality engineer. Photos archived."
     },
     specificationBooks: [
       {
@@ -231,10 +263,12 @@ export const tenders: Tender[] = [
     dueDate: date(20),
     createdAt: date(-21),
     siteVisit: {
+      required: true,
+      completed: false,
+      photos: [],
       date: date(5),
       assignee: "Omar Ghat",
-      notes: "Awaiting security clearance to confirm visit schedule.",
-      completed: false
+      notes: "Awaiting security clearance to confirm visit schedule."
     },
     specificationBooks: [
       {
@@ -327,10 +361,12 @@ export const tenders: Tender[] = [
     dueDate: date(-28),
     createdAt: date(-90),
     siteVisit: {
+      required: false,
+      completed: true,
+      photos: tripoliVisitPhotos,
       date: date(-60),
       assignee: "Layla Ben Ali",
-      notes: "Joint inspection with IOM engineer. Guarantee renewal flagged for finance.",
-      completed: true
+      notes: "Joint inspection with IOM engineer. Guarantee renewal flagged for finance."
     },
     specificationBooks: [
       {

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -14,10 +14,12 @@ export type TenderLink = {
 };
 
 export type TenderSiteVisit = {
+  required: boolean;
+  completed: boolean;
+  photos: Attachment[];
   date?: string | null;
   assignee?: string;
   notes?: string;
-  completed: boolean;
 };
 
 export type SpecificationBook = {


### PR DESCRIPTION
## Summary
- extend tender site visit data with required flag, scheduled details, and photo attachments persisted through the mock API
- surface site visit requirements in the tender drawer and list, and add a toggle-driven step in the create modal with drag-and-drop photo uploads
- enrich seed data and CSV exports with site visit date and assignee columns for downstream reporting

## Testing
- npm run build *(fails: vite not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d69e0a2284832599e354607286cb6a