### PR TITLE
Add specification booklet purchase toggle

### DIFF
--- a/frontend/src/data/seed.ts
+++ b/frontend/src/data/seed.ts
@@ -152,6 +152,7 @@ export const tenders: Tender[] = [
       {
         id: "book-1",
         number: "ITB-2024-017",
+        purchased: true,
         purchaseDate: date(-18),
         cost: 250,
         currency: "USD",
@@ -274,6 +275,7 @@ export const tenders: Tender[] = [
       {
         id: "book-2",
         number: "ITB-2024-221",
+        purchased: false,
         purchaseDate: null,
         cost: 0,
         currency: "EUR",
@@ -372,6 +374,7 @@ export const tenders: Tender[] = [
       {
         id: "book-3",
         number: "RFP-2024-044",
+        purchased: true,
         purchaseDate: date(-80),
         cost: 300,
         currency: "USD",
@@ -382,6 +385,7 @@ export const tenders: Tender[] = [
       {
         id: "book-4",
         number: "RFP-2024-044-LOT2",
+        purchased: true,
         purchaseDate: date(-78),
         cost: 180,
         currency: "USD",

--- a/frontend/src/providers/language-provider.tsx
+++ b/frontend/src/providers/language-provider.tsx
@@ -59,6 +59,8 @@ export type DictionaryKey =
   | "specificationBookStatusPurchased"
   | "specificationBookStatusMissing"
   | "specificationBookReceipt"
+  | "specificationBookPurchasedQuestion"
+  | "specificationBookPurchaseHint"
   | "addSpecificationBook"
   | "proposals"
   | "technicalProposal"
@@ -152,6 +154,8 @@ const dictionaries: Record<Locale, Dictionary> = {
     specificationBookStatusPurchased: "Purchased",
     specificationBookStatusMissing: "Not purchased",
     specificationBookReceipt: "Receipt",
+    specificationBookPurchasedQuestion: "Was the specification booklet purchased?",
+    specificationBookPurchaseHint: "Enable to enter purchase costs, receipts, and responsible details.",
     addSpecificationBook: "Add booklet",
     proposals: "Proposals",
     technicalProposal: "Technical proposal URL",
@@ -238,6 +242,8 @@ const dictionaries: Record<Locale, Dictionary> = {
     specificationBookStatusPurchased: "تم الشراء",
     specificationBookStatusMissing: "غير مشتراة",
     specificationBookReceipt: "الإيصال",
+    specificationBookPurchasedQuestion: "هل تم شراء كراسة المواصفات؟",
+    specificationBookPurchaseHint: "فعّل هذا الخيار لإدخال التكاليف والإيصالات وبيانات المسؤول.",
     addSpecificationBook: "إضافة كراسة",
     proposals: "العروض",
     technicalProposal: "رابط العرض الفني",

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -25,6 +25,7 @@ export type TenderSiteVisit = {
 export type SpecificationBook = {
   id: string;
   number: string;
+  purchased: boolean;
   purchaseDate?: string | null;
   cost: number;
   currency: string;


### PR DESCRIPTION
## Summary
- add a purchased flag to specification booklets and surface it through the tender drawer and creation flow
- gate cost, receipt, and responsibility inputs on the purchased toggle and hide those details in read views when the booklet is not bought
- normalize stored tenders and seed data so the new booklet purchase state persists correctly

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a28414ec83258706a7e330b10026