### PR TITLE
Fix mock API initialization order

### DIFF
--- a/frontend/src/services/mockApi.ts
+++ b/frontend/src/services/mockApi.ts
@@ -274,26 +274,6 @@ function persist(db: DatabaseShape) {
   window.localStorage.setItem(STORAGE_KEY, JSON.stringify(db));
 }
 
-let database = loadDatabase();
-
-window.addEventListener("storage", (event) => {
-  if (event.key === STORAGE_KEY && event.newValue) {
-    const parsed = JSON.parse(event.newValue) as Partial<DatabaseShape>;
-    database = {
-      tenders: (Array.isArray(parsed.tenders) ? parsed.tenders : seedTenders).map((tender) =>
-        normalizeTenderRecord(tender as Tender)
-      ),
-      projects: Array.isArray(parsed.projects) ? parsed.projects : seedProjects,
-      suppliers: Array.isArray(parsed.suppliers) ? parsed.suppliers : seedSuppliers,
-      invoices: Array.isArray(parsed.invoices) ? parsed.invoices : seedInvoices,
-      notifications: Array.isArray(parsed.notifications)
-        ? parsed.notifications
-        : seedNotifications,
-      users: Array.isArray(parsed.users) ? parsed.users : seedUsers
-    };
-  }
-});
-
 const generateId = (prefix: string) => `${prefix}-${crypto.randomUUID()}`;
 
 export async function fetchDashboard() {
@@ -440,6 +420,26 @@ const mergePricing = (existing: TenderPricing, incoming?: Partial<TenderPricing>
     summary: summarizePricing(lines)
   };
 };
+
+let database = loadDatabase();
+
+window.addEventListener("storage", (event) => {
+  if (event.key === STORAGE_KEY && event.newValue) {
+    const parsed = JSON.parse(event.newValue) as Partial<DatabaseShape>;
+    database = {
+      tenders: (Array.isArray(parsed.tenders) ? parsed.tenders : seedTenders).map((tender) =>
+        normalizeTenderRecord(tender as Tender)
+      ),
+      projects: Array.isArray(parsed.projects) ? parsed.projects : seedProjects,
+      suppliers: Array.isArray(parsed.suppliers) ? parsed.suppliers : seedSuppliers,
+      invoices: Array.isArray(parsed.invoices) ? parsed.invoices : seedInvoices,
+      notifications: Array.isArray(parsed.notifications)
+        ? parsed.notifications
+        : seedNotifications,
+      users: Array.isArray(parsed.users) ? parsed.users : seedUsers
+    };
+  }
+});
 
 const mergeSiteVisit = (
   existing?: TenderSiteVisit,


### PR DESCRIPTION
## Summary
- move the mock API database initialization and storage listener until after all tender normalization helpers are defined to prevent ReferenceErrors during load

## Testing
- npm install *(fails: 403 Forbidden from registry.npmjs.org)*
- npm run build *(fails: vite: not found due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d6e736ea9c8325bab73aa0b7c86a0c