### PR TITLE
Guard crypto.randomUUID usage in mock API service

### DIFF
--- a/frontend/src/services/mockApi.ts
+++ b/frontend/src/services/mockApi.ts
@@ -274,7 +274,7 @@ function persist(db: DatabaseShape) {
   window.localStorage.setItem(STORAGE_KEY, JSON.stringify(db));
 }
 
-const generateId = (prefix: string) => `${prefix}-${crypto.randomUUID()}`;
+const generateId = (prefix: string) => fallbackRandomId(prefix);
 
 export async function fetchDashboard() {
   await latency();


### PR DESCRIPTION
## Summary
- update generateId to reuse the existing fallbackRandomId helper and avoid direct crypto.randomUUID access

## Testing
- npm run build *(fails: vite: not found after npm install was blocked by 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d6e93c119c8325ba6b654686ce3e19