### PR TITLE
Improve crypto fallback resolution and tests

### DIFF
--- a/frontend/src/services/__tests__/loadDatabase.test.ts
+++ b/frontend/src/services/__tests__/loadDatabase.test.ts
@@ -1,28 +1,24 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { tenders as seedTenders } from "@/data/seed";
 
 const STORAGE_KEY = "tender-portal-demo";
 
 describe("mockApi loadDatabase migrations", () => {
-  beforeAll(() => {
-    vi.stubGlobal("crypto", {
-      randomUUID: () => "00000000-0000-0000-0000-000000000000",
-      getRandomValues: (array: Uint8Array) => array.fill(0)
-    });
-  });
-
-  afterAll(() => {
-    vi.unstubAllGlobals();
-  });
+  const cryptoStub = {
+    randomUUID: () => "00000000-0000-0000-0000-000000000000",
+    getRandomValues: (array: Uint8Array) => array.fill(0)
+  } satisfies Pick<Crypto, "randomUUID" | "getRandomValues">;
 
   beforeEach(() => {
+    vi.stubGlobal("crypto", cryptoStub);
     localStorage.clear();
     vi.resetModules();
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.unstubAllGlobals();
   });
 
   it("seeds fresh data with alerts populated", async () => {
@@ -64,5 +60,63 @@ describe("mockApi loadDatabase migrations", () => {
 
     const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}") as any;
     expect(persisted?.tenders?.[0]?.alerts?.submissionReminderAt ?? undefined).not.toBeUndefined();
+  });
+
+  it("falls back to window.msCrypto when globalThis is unavailable", async () => {
+    const root = globalThis as typeof globalThis & {
+      window?: Record<string, unknown>;
+      self?: Record<string, unknown>;
+    };
+
+    const originalGlobalThisDescriptor = Object.getOwnPropertyDescriptor(root, "globalThis");
+    const originalWindow = root.window;
+    const originalSelf = root.self;
+    const originalCrypto = (root as typeof root & { crypto?: Crypto | undefined }).crypto;
+
+    const msCrypto: Pick<Crypto, "getRandomValues"> & Partial<Crypto> = {
+      getRandomValues: vi.fn((array: Uint8Array) => array.fill(0))
+    };
+
+    try {
+      Object.defineProperty(root, "globalThis", {
+        value: undefined,
+        configurable: true,
+        writable: true
+      });
+
+      root.window = { msCrypto };
+      root.self = { msCrypto };
+      (root as typeof root & { crypto?: Crypto | undefined }).crypto = undefined;
+
+      const { prefixedRandomId } = await import("@/utils/random");
+      const id = prefixedRandomId("ms");
+
+      expect(id).toBe("ms-00000000-0000-4000-8000-000000000000");
+      expect(msCrypto.getRandomValues).toHaveBeenCalledTimes(1);
+    } finally {
+      if (originalGlobalThisDescriptor) {
+        Object.defineProperty(root, "globalThis", originalGlobalThisDescriptor);
+      } else {
+        delete (root as typeof root & { globalThis?: unknown }).globalThis;
+      }
+
+      if (originalWindow === undefined) {
+        delete root.window;
+      } else {
+        root.window = originalWindow;
+      }
+
+      if (originalSelf === undefined) {
+        delete root.self;
+      } else {
+        root.self = originalSelf;
+      }
+
+      if (originalCrypto === undefined) {
+        delete (root as typeof root & { crypto?: Crypto | undefined }).crypto;
+      } else {
+        (root as typeof root & { crypto?: Crypto | undefined }).crypto = originalCrypto;
+      }
+    }
   });
 });


### PR DESCRIPTION
## Summary
- broaden the crypto resolver to search legacy globals (self, window, msCrypto, global)
- keep the random UUID helpers type-safe by returning Crypto-compatible objects
- add coverage that exercises the no-globalThis path to ensure IDs are still seeded

## Testing
- npm --prefix frontend test -- --runInBand *(fails: vitest executable not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d724a38744832584357a72532cb970