### PR TITLE
Fix mock API database initialization order

### DIFF
--- a/frontend/src/services/mockApi.ts
+++ b/frontend/src/services/mockApi.ts
@@ -417,26 +417,6 @@ const mergePricing = (existing: TenderPricing, incoming?: Partial<TenderPricing>
   };
 };
 
-let database = loadDatabase();
-
-window.addEventListener("storage", (event) => {
-  if (event.key === STORAGE_KEY && event.newValue) {
-    const parsed = JSON.parse(event.newValue) as Partial<DatabaseShape>;
-    database = {
-      tenders: (Array.isArray(parsed.tenders) ? parsed.tenders : seedTenders).map((tender) =>
-        normalizeTenderRecord(tender as Tender)
-      ),
-      projects: Array.isArray(parsed.projects) ? parsed.projects : seedProjects,
-      suppliers: Array.isArray(parsed.suppliers) ? parsed.suppliers : seedSuppliers,
-      invoices: Array.isArray(parsed.invoices) ? parsed.invoices : seedInvoices,
-      notifications: Array.isArray(parsed.notifications)
-        ? parsed.notifications
-        : seedNotifications,
-      users: Array.isArray(parsed.users) ? parsed.users : seedUsers
-    };
-  }
-});
-
 const mergeSiteVisit = (
   existing?: TenderSiteVisit,
   incoming?: Partial<TenderSiteVisit>
@@ -472,6 +452,26 @@ const mergeSiteVisit = (
 
   return next;
 };
+
+let database = loadDatabase();
+
+window.addEventListener("storage", (event) => {
+  if (event.key === STORAGE_KEY && event.newValue) {
+    const parsed = JSON.parse(event.newValue) as Partial<DatabaseShape>;
+    database = {
+      tenders: (Array.isArray(parsed.tenders) ? parsed.tenders : seedTenders).map((tender) =>
+        normalizeTenderRecord(tender as Tender)
+      ),
+      projects: Array.isArray(parsed.projects) ? parsed.projects : seedProjects,
+      suppliers: Array.isArray(parsed.suppliers) ? parsed.suppliers : seedSuppliers,
+      invoices: Array.isArray(parsed.invoices) ? parsed.invoices : seedInvoices,
+      notifications: Array.isArray(parsed.notifications)
+        ? parsed.notifications
+        : seedNotifications,
+      users: Array.isArray(parsed.users) ? parsed.users : seedUsers
+    };
+  }
+});
 
 export async function saveTender(
   tender: Partial<Tender> & { title?: string }


### PR DESCRIPTION
## Summary
- move the mock API database initialization and storage sync to after the pricing helpers so normalizeTenderRecord can safely call them

## Testing
- npm install *(fails: 403 Forbidden fetching @radix-ui/react-dialog)*

------
https://chatgpt.com/codex/tasks/task_e_68d729d5249c8325aa5efd1e184bc2e9