### PR TITLE
Fix mock API initialization ordering

### DIFF
--- a/frontend/src/services/mockApi.ts
+++ b/frontend/src/services/mockApi.ts
@@ -199,35 +199,6 @@ const normalizeTenderRecord = (tender: Tender): Tender => {
   return { ...normalized, aiInsights: ensureAiInsights(normalized) };
 };
 
-const generateId = (prefix: string) => prefixedRandomId(prefix);
-
-export async function fetchDashboard() {
-  await latency();
-  return {
-    metrics: dashboardMetrics,
-    pipeline: pipelineBreakdown,
-    cashflow,
-    notifications: database.notifications
-  } as {
-    metrics: DashboardMetric[];
-    pipeline: PipelineBreakdown[];
-    cashflow: CashflowPoint[];
-    notifications: Notification[];
-  };
-}
-
-export async function listTenders(): Promise<Tender[]> {
-  await latency();
-  return [...database.tenders].sort((a, b) =>
-    b.createdAt.localeCompare(a.createdAt)
-  );
-}
-
-export async function getTender(id: string): Promise<Tender | undefined> {
-  await latency();
-  return database.tenders.find((tender) => tender.id === id);
-}
-
 function createEmptySummary(): TenderPricingSummary {
   return {
     subtotalUsd: 0,
@@ -459,6 +430,8 @@ function persist(db: DatabaseShape) {
   window.localStorage.setItem(STORAGE_KEY, JSON.stringify(db));
 }
 
+const generateId = (prefix: string) => prefixedRandomId(prefix);
+
 let database = loadDatabase();
 
 window.addEventListener("storage", (event) => {
@@ -478,6 +451,33 @@ window.addEventListener("storage", (event) => {
     };
   }
 });
+
+export async function fetchDashboard() {
+  await latency();
+  return {
+    metrics: dashboardMetrics,
+    pipeline: pipelineBreakdown,
+    cashflow,
+    notifications: database.notifications
+  } as {
+    metrics: DashboardMetric[];
+    pipeline: PipelineBreakdown[];
+    cashflow: CashflowPoint[];
+    notifications: Notification[];
+  };
+}
+
+export async function listTenders(): Promise<Tender[]> {
+  await latency();
+  return [...database.tenders].sort((a, b) =>
+    b.createdAt.localeCompare(a.createdAt)
+  );
+}
+
+export async function getTender(id: string): Promise<Tender | undefined> {
+  await latency();
+  return database.tenders.find((tender) => tender.id === id);
+}
 
 export async function saveTender(
   tender: Partial<Tender> & { title?: string }


### PR DESCRIPTION
## Summary
- move the mock API database initialization and storage listener to run after helper declarations
- ensure `fetchDashboard`, `listTenders`, and `getTender` remain functional with the reordered initialization

## Testing
- npm install *(fails: registry returned 403 for @radix-ui/react-dialog)*

------
https://chatgpt.com/codex/tasks/task_e_68d73791f0c883259531db0eff88b629